### PR TITLE
Fix on collapsible section clickable icon

### DIFF
--- a/src/common/Accordion/AccordionSingle.tsx
+++ b/src/common/Accordion/AccordionSingle.tsx
@@ -108,6 +108,14 @@ const StyledTrigger = styled(AccordionTriggerPrimitive)`
 
     margin-bottom: 0.75em;
   }
+
+  svg {
+    position: absolute;
+  }
+
+  [data-stylizable='widget string-listarray accordion-header'] {
+    margin-left: 2rem;
+  }
 `
 
 const StyledChevron = styled(ChevronDownIcon)``


### PR DESCRIPTION
Issue : COPDS-1394
The goal is to move the icon to the left of the clickable section